### PR TITLE
Refactor HTTP utilities and add functional options

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -21,8 +21,8 @@ type data struct {
 
 // Memory 实现一个内存缓存
 type Memory struct {
-	sync.Mutex // 读写锁
-	data       map[string]*data
+	sync.RWMutex // 读写锁
+	data         map[string]*data
 }
 
 // NewMemory 实例化一个内存缓存器
@@ -34,10 +34,11 @@ func NewMemory() Cache {
 
 // Get 获取缓存的值
 func (mem *Memory) Get(key string) interface{} {
-	if val, ok := mem.data[key]; ok {
-		// 判断缓存是否过期
+	mem.RLock()
+	val, ok := mem.data[key]
+	mem.RUnlock()
+	if ok {
 		if val.Expired.Before(time.Now()) {
-			// 删除这个key
 			mem.deleteKey(key)
 			return nil
 		}
@@ -59,7 +60,10 @@ func (mem *Memory) Set(key string, val interface{}, timeout time.Duration) error
 
 // IsExist 判断值是否存在
 func (mem *Memory) IsExist(key string) bool {
-	if val, ok := mem.data[key]; ok {
+	mem.RLock()
+	val, ok := mem.data[key]
+	mem.RUnlock()
+	if ok {
 		if val.Expired.Before(time.Now()) {
 			return false
 		}

--- a/douyin_openapi.go
+++ b/douyin_openapi.go
@@ -46,8 +46,39 @@ type DouYinOpenApi struct {
 	BaseApi string
 }
 
+// Option defines a function which configures DouYinOpenApiConfig.
+type Option func(*DouYinOpenApiConfig)
+
+// WithCache sets a custom cache implementation.
+func WithCache(c cache.Cache) Option {
+	return func(cfg *DouYinOpenApiConfig) { cfg.Cache = c }
+}
+
+// WithAccessToken sets a custom AccessToken implementation.
+func WithAccessToken(at accessToken.AccessToken) Option {
+	return func(cfg *DouYinOpenApiConfig) { cfg.AccessToken = at }
+}
+
+// WithSandbox enables sandbox mode.
+func WithSandbox() Option { return func(cfg *DouYinOpenApiConfig) { cfg.IsSandbox = true } }
+
+// WithToken sets callback token.
+func WithToken(token string) Option { return func(cfg *DouYinOpenApiConfig) { cfg.Token = token } }
+
+// WithSalt sets sign salt.
+func WithSalt(salt string) Option { return func(cfg *DouYinOpenApiConfig) { cfg.Salt = salt } }
+
 // NewDouYinOpenApi 实例化一个抖音openapi实例
-func NewDouYinOpenApi(config DouYinOpenApiConfig) *DouYinOpenApi {
+func NewDouYinOpenApi(appId, appSecret string, opts ...Option) *DouYinOpenApi {
+	config := DouYinOpenApiConfig{AppId: appId, AppSecret: appSecret}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return newDouYinOpenApi(config)
+}
+
+// newDouYinOpenApi creates DouYinOpenApi instance based on config.
+func newDouYinOpenApi(config DouYinOpenApiConfig) *DouYinOpenApi {
 	if config.Cache == nil {
 		config.Cache = cache.NewMemory()
 	}

--- a/douyin_openapi_test.go
+++ b/douyin_openapi_test.go
@@ -28,13 +28,10 @@ var OpenApi *DouYinOpenApi
 
 func init() {
 	Cache = cache.NewMemory()
-	OpenApi = NewDouYinOpenApi(DouYinOpenApiConfig{
-		AppId:     AppId,
-		AppSecret: AppSecret,
-		IsSandbox: false,
-		Token:     Token,
-		Salt:      Salt,
-	})
+	OpenApi = NewDouYinOpenApi(AppId, AppSecret,
+		WithCache(Cache),
+		WithToken(Token),
+		WithSalt(Salt))
 }
 
 // 不足位数补零

--- a/util/http.go
+++ b/util/http.go
@@ -2,16 +2,31 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
+	"time"
 )
 
+// HTTPDoer represents the minimal interface required to execute an HTTP request.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+var defaultClient HTTPDoer = &http.Client{Timeout: 10 * time.Second}
+
 // PostForm post form 数据请求
-func PostForm(uri string, obj url.Values) ([]byte, error) {
-	response, err := http.PostForm(uri, obj)
+func PostFormCtx(ctx context.Context, client HTTPDoer, uri string, obj url.Values) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uri, strings.NewReader(obj.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -23,13 +38,22 @@ func PostForm(uri string, obj url.Values) ([]byte, error) {
 	return ioutil.ReadAll(response.Body)
 }
 
+func PostForm(uri string, obj url.Values) ([]byte, error) {
+	return PostFormCtx(context.Background(), defaultClient, uri, obj)
+}
+
 // PostJSON post json 数据请求
-func PostJSON(uri string, obj interface{}) ([]byte, error) {
+func PostJSONCtx(ctx context.Context, client HTTPDoer, uri string, obj interface{}) ([]byte, error) {
 	marshal, err := json.Marshal(obj)
 	if err != nil {
 		return nil, err
 	}
-	response, err := http.Post(uri, "application/json;charset=utf-8", bytes.NewBuffer(marshal))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uri, bytes.NewBuffer(marshal))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json;charset=utf-8")
+	response, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -39,6 +63,10 @@ func PostJSON(uri string, obj interface{}) ([]byte, error) {
 		return nil, fmt.Errorf("http get error : uri=%v , statusCode=%v", uri, response.StatusCode)
 	}
 	return ioutil.ReadAll(response.Body)
+}
+
+func PostJSON(uri string, obj interface{}) ([]byte, error) {
+	return PostJSONCtx(context.Background(), defaultClient, uri, obj)
 }
 
 // JsonStructToMap ...


### PR DESCRIPTION
## Summary
- add customizable HTTP client with context support
- use RWMutex in memory cache for safe concurrent reads
- implement functional options for DouYinOpenApi construction
- update tests to use new builder

## Testing
- `go vet ./...`
- `go test ./...` *(fails: Post "https://developer.toutiao.com/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6841023e064c832a970bb0cb5118d11c